### PR TITLE
Speed up the inference of Whisper with pad_or_trim (30s -> 10s)

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -14,7 +14,7 @@ SAMPLE_RATE = 16000
 N_FFT = 400
 N_MELS = 80
 HOP_LENGTH = 160
-CHUNK_LENGTH = 30
+CHUNK_LENGTH = 10
 N_SAMPLES = CHUNK_LENGTH * SAMPLE_RATE  # 480000: number of samples in a chunk
 N_FRAMES = exact_div(N_SAMPLES, HOP_LENGTH)  # 3000: number of frames in a mel spectrogram input
 


### PR DESCRIPTION
Initialize model like following

```
import efficient_whisper as whisper


checkpoint = torch.load('~/.cache/whisper/large.pt', map_location='cpu')
dims = whisper.model.ModelDimensions(**checkpoint["dims"])
dims.n_audio_ctx = 500  # 10 sec

model = whisper.model.Whisper(dims)
for k, p in model.state_dict().items():
    p.copy_(checkpoint["model_state_dict"][k])

model.encoder = torch.jit.script(model.encoder)
model.decoder = torch.jit.script(model.decoder)
_ = model.half()
_ = model.cuda()
```